### PR TITLE
Add pause and stop

### DIFF
--- a/Example/kMusicSwift/Base.lproj/Main.storyboard
+++ b/Example/kMusicSwift/Base.lproj/Main.storyboard
@@ -19,25 +19,43 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eLM-BE-EDl">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SyX-K9-cwb">
+                                <rect key="frame" x="16" y="399" width="351" height="38"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="STOP">
+                                    <fontDescription key="titleFontDescription" type="system" weight="black" pointSize="20"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="onStop:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="33T-ND-LUi"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eLM-BE-EDl">
                                 <rect key="frame" x="162" y="318" width="51" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Play"/>
                                 <connections>
-                                    <action selector="onPlay:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="n3r-ak-cDz"/>
+                                    <action selector="onPlayOrPauseWithSender:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="qpE-bn-UU4"/>
                                 </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="SyX-K9-cwb" secondAttribute="trailing" constant="8" id="8I9-4a-Vo7"/>
+                            <constraint firstItem="eLM-BE-EDl" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="99W-qu-SNu"/>
+                            <constraint firstItem="eLM-BE-EDl" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="ABg-qg-MnP"/>
+                            <constraint firstItem="SyX-K9-cwb" firstAttribute="top" secondItem="eLM-BE-EDl" secondAttribute="bottom" constant="50" id="NOB-4b-OQb"/>
+                            <constraint firstItem="SyX-K9-cwb" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="16" id="Tna-qq-NwP"/>
+                        </constraints>
                     </view>
                     <connections>
+                        <outlet property="playOrPauseBtn" destination="eLM-BE-EDl" id="DRv-1P-hJL"/>
+                        <outlet property="stopBtn" destination="SyX-K9-cwb" id="2E1-qF-TTT"/>
                         <outlet property="view" destination="eLM-BE-EDl" id="C8o-SW-VBb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="138" y="128"/>
+            <point key="canvasLocation" x="136.80000000000001" y="127.28635682158921"/>
         </scene>
     </scenes>
 </document>

--- a/Example/kMusicSwift/ViewController.swift
+++ b/Example/kMusicSwift/ViewController.swift
@@ -13,6 +13,8 @@ import UIKit
 @available(iOS 15.0, *)
 class ViewController: UIViewController {
     let jap = JustAudioPlayer()
+    @IBOutlet var playOrPauseBtn: UIButton!
+    @IBOutlet var stopBtn: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,11 +33,19 @@ class ViewController: UIViewController {
         }
     }
 
-    @IBAction func onPlay(_: Any) {
-        jap.play()
+    @IBAction func onPlayOrPause(sender: UIButton) {
+        if jap.isPlaying {
+            jap.pause()
+            sender.setTitle("Play", for: .normal)
+        } else {
+            jap.play()
+            sender.setTitle("Pause", for: .normal)
+        }
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
+    @IBAction func onStop(_: Any) {
+        jap.stop()
+        playOrPauseBtn.setTitle("Play", for: .normal)
+        // TODO: reset the jap's queue tracks after stop, otherwise it will not work
     }
 }

--- a/kMusicSwift/Classes/JustAudioPlayer.swift
+++ b/kMusicSwift/Classes/JustAudioPlayer.swift
@@ -31,6 +31,10 @@ public enum LoopMode {
 
 @available(iOS 15.0, *)
 public class JustAudioPlayer {
+    public var isPlaying: Bool {
+        playerNode.isPlaying
+    }
+
     private let engine: AVAudioEngine = .init()
     private let playerNode: AVAudioPlayerNode = .init()
 
@@ -81,6 +85,7 @@ public class JustAudioPlayer {
     }
 
     public func stop() {
+        queue.removeAll()
         playerNode.stop()
         engine.stop()
     }


### PR DESCRIPTION
- implement pause and stop
- stop function will delete the tracks queue, but for now, the engine can be reused after the stop, without reimplementing it, but if the user will do the play action, without setting a new track the JAP will crash 
- exposed a var `isPlaying` from JAP representing if the player is playing a song/track or not