### PR TITLE
Update buffer property

### DIFF
--- a/kMusicSwift/Classes/JustAudioPlayer.swift
+++ b/kMusicSwift/Classes/JustAudioPlayer.swift
@@ -331,7 +331,7 @@ private extension JustAudioPlayer {
         streamingBufferSubscription = SAPlayer.Updates.StreamingBuffer
             .subscribe { [weak self] buffer in
                 // TODO: once we hook to the UI verify this is the correct value to proxy
-                self?.bufferPosition = buffer.totalDurationBuffered
+                self?.bufferPosition = buffer.bufferingProgress
             }
     }
 


### PR DESCRIPTION
From the [SwiftAudioPlayer docs](https://github.com/tanhakabir/SwiftAudioPlayer#usage)

> To receive streaming progress (for buffer progress %):

```swift
@IBOutlet weak var bufferProgress: UIProgressView!

override func viewDidLoad() {
    super.viewDidLoad()

    _ = SAPlayer.Updates.StreamingBuffer.subscribe{ [weak self] buffer in
        guard let self = self else { return }

        self.bufferProgress.progress = Float(buffer.bufferingProgress)

        self.isPlayable = buffer.isReadyForPlaying
    }
}
```