### PR TITLE
feat: multiple audio tracks playing simultaneously

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - kMusicSwift (0.1.0):
-    - SwiftAudioPlayerKuama (~> 7.6.2)
-  - SwiftAudioPlayerKuama (7.6.2)
+    - SwiftAudioPlayerKuama (~> 7.6.3)
+  - SwiftAudioPlayerKuama (7.6.3)
 
 DEPENDENCIES:
   - kMusicSwift (from `../`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  kMusicSwift: e871f3bfbf8c6c622a386c06ca85ceb7a40f3009
-  SwiftAudioPlayerKuama: 9feeeb234358c2e0d52544ee727aedf317def515
+  kMusicSwift: 692c3e3017f3dfcede699c7305bcc8f9fc01d3d4
+  SwiftAudioPlayerKuama: 90edf9b57052ffd7fa3977da66c22380621e394a
 
-PODFILE CHECKSUM: 56b5c5cd8a151468f127f587a453ddd32157520d
+PODFILE CHECKSUM: 5805fcd40facc084da74658d0ff1cf9ffe7e6f40
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/Example/kMusicSwift.xcodeproj/project.pbxproj
+++ b/Example/kMusicSwift.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		8E0D205B28BE5BE700F61FD6 /* RoundingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0D205A28BE5BE700F61FD6 /* RoundingHelper.swift */; };
 		8E635AB10AFE63763614E7A4 /* Pods_kMusicSwift_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 280912CFB320E014046914EF /* Pods_kMusicSwift_Example.framework */; };
+		8E80C69128D4B43800A7FD5C /* shakerando.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8E80C69028D4B43800A7FD5C /* shakerando.mp3 */; };
 		8E93654228C89D08002C3B80 /* random.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8E93654128C89D08002C3B80 /* random.mp3 */; };
 		D7626FA04D9813DCF1343B24 /* Pods_kMusicSwift_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39FBB6159A56EACF46D19F37 /* Pods_kMusicSwift_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -55,6 +56,7 @@
 		7CF5828A2557254E43E0F09D /* Pods-kMusicSwift_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kMusicSwift_Tests.debug.xcconfig"; path = "Target Support Files/Pods-kMusicSwift_Tests/Pods-kMusicSwift_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		82332E10B24C9B6D9EFDE70C /* Pods-kMusicSwift_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kMusicSwift_Example.release.xcconfig"; path = "Target Support Files/Pods-kMusicSwift_Example/Pods-kMusicSwift_Example.release.xcconfig"; sourceTree = "<group>"; };
 		8E0D205A28BE5BE700F61FD6 /* RoundingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundingHelper.swift; sourceTree = "<group>"; };
+		8E80C69028D4B43800A7FD5C /* shakerando.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = shakerando.mp3; sourceTree = "<group>"; };
 		8E93654128C89D08002C3B80 /* random.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = random.mp3; sourceTree = "<group>"; };
 		9331F8579A60E43ADC7DAB13 /* Pods-kMusicSwift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kMusicSwift_Tests.release.xcconfig"; path = "Target Support Files/Pods-kMusicSwift_Tests/Pods-kMusicSwift_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		94DD4CCDCDF86874A7626EBD /* kMusicSwift.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = kMusicSwift.podspec; path = ../kMusicSwift.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -107,6 +109,7 @@
 			children = (
 				048538C228BE2ECC003454FD /* nature.mp3 */,
 				04DFEF3028BCA35A00DCE3DA /* AudioSource.mp3 */,
+				8E80C69028D4B43800A7FD5C /* shakerando.mp3 */,
 				8E93654128C89D08002C3B80 /* random.mp3 */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
@@ -271,6 +274,7 @@
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				04DFEF3128BCA35A00DCE3DA /* AudioSource.mp3 in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
+				8E80C69128D4B43800A7FD5C /* shakerando.mp3 in Resources */,
 				8E93654228C89D08002C3B80 /* random.mp3 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/kMusicSwift/ViewController.swift
+++ b/Example/kMusicSwift/ViewController.swift
@@ -13,7 +13,9 @@ import UIKit
 
 @available(iOS 15.0, *)
 class ViewController: UIViewController {
-    private lazy var jap = JustAudioPlayer()
+    private lazy var engine = AVAudioEngine()
+    private lazy var jap = JustAudioPlayer(engine: engine)
+    private lazy var jap2 = JustAudioPlayer(engine: engine)
     @IBOutlet var playOrPauseBtn: UIButton!
     @IBOutlet var stopBtn: UIButton!
     @IBOutlet var loopModeBtn: UIButton!
@@ -137,13 +139,14 @@ class ViewController: UIViewController {
         distortion.setBypass(false)
         distortion.setWetDryMix(40)
 
-        _ = RemoteAudioSource(at: "https://www.fesliyanstudios.com/musicfiles/2019-04-23_-_Trusted_Advertising_-" +
+        let remote = RemoteAudioSource(at: "https://www.fesliyanstudios.com/musicfiles/2019-04-23_-_Trusted_Advertising_-" +
             "_www.fesliyanstudios.com/15SecVersion2019-04-23_-_Trusted_Advertising_-_www.fesliyanstudios.com.mp3",
-            effects: [delay])
+            effects: [])
 //        let local = LocalAudioSource(at: "AudioSource.mp3", effects: [delay])
-        let local = LocalAudioSource(at: "AudioSource.mp3", effects: [reverb])
+//        let local = LocalAudioSource(at: "AudioSource.mp3", effects: [reverb])
+        let shakerando = LocalAudioSource(at: "shakerando.mp3")
 //        let local = LocalAudioSource(at: "AudioSource.mp3", effects: [distortion])
-//        let local = LocalAudioSource(at: "AudioSource.mp3", effects: [])
+        let local = LocalAudioSource(at: "AudioSource.mp3", effects: [])
         do {
             let eq = try Equalizer(preSets: [
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -152,18 +155,96 @@ class ViewController: UIViewController {
                 [5, 4, 3.5, 3, 1, 0, 0, 0, 0, 0],
             ])
             try jap.setEqualizer(eq)
-            /*
-             _ = try ClippingAudioSource(with: local, from: 10.0, to: 15.0)
+            _ = try ClippingAudioSource(with: local, from: 10.0, to: 15.0)
 
-             try jap.writeOutputToFile()*/
+            try jap.writeOutputToFile()
 
-            jap.addAudioSource(IndexedAudioSequence(with: local))
+            jap.addAudioSource(IndexedAudioSequence(with: remote))
             try jap.setVolume(0.1)
             jap.setLoopMode(.off)
             try jap.play()
+
+            jap2.addAudioSource(IndexedAudioSequence(with: shakerando))
+            try jap2.setVolume(0.2)
+            try jap2.play()
+
         } catch {
             handleError(error: error)
         }
+
+        jap2Streams()
+    }
+
+    private func jap2Streams() {
+        jap2.$speed
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 SPEED")
+            }).store(in: &cancellables)
+
+        jap2.$duration
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 DURATION")
+            }).store(in: &cancellables)
+
+        jap2.$queueIndex
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 QUEUE INDEX")
+            }).store(in: &cancellables)
+
+        jap2.$elapsedTime
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 ELAPSED TIME")
+//                if $0 > 5{
+//                    self.jap2.pause()
+//                }
+            }).store(in: &cancellables)
+
+        jap2.$loopMode
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 LOOP MODE")
+            }).store(in: &cancellables)
+
+        jap2.$volume
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 VOLUME")
+            }).store(in: &cancellables)
+
+        jap2.isShuffling
+            .compactMap { $0 }.receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 IS SHUFFLING")
+            }).store(in: &cancellables)
+
+        jap2.$isPlaying
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 IS PLAYING")
+            }).store(in: &cancellables)
+
+        jap2.$outputWriteError
+            .compactMap { $0 }.receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 OUTPUT WRITE ERROR")
+            }).store(in: &cancellables)
+
+        jap2.$outputAbsolutePath
+            .compactMap { $0 }.receive(on: DispatchQueue.main)
+            .sink(receiveValue: {
+                print("\($0) JAP2 ABSOLUTE PATH")
+            }).store(in: &cancellables)
     }
 
     @IBAction func onPlayOrPause(sender _: UIButton) {

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 - [x] Playlist editing
 
 # Audio effects
-- [ ] Multiple tracks in one time
+- [x] Multiple tracks in one time
 - [x] Audio effects on a per-track basis
 - [x] Mixer
 - [x] Mixer presets

--- a/kMusicSwift.podspec
+++ b/kMusicSwift.podspec
@@ -23,6 +23,6 @@ See https://github.com/ryanheise/just_audio/tree/minor/just_audio#readme for a f
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'SwiftAudioPlayerKuama', '~> 7.6.2'
+  s.dependency 'SwiftAudioPlayerKuama', '~> 7.6.3'
 end
 

--- a/kMusicSwift/Classes/JustAudioPlayer.swift
+++ b/kMusicSwift/Classes/JustAudioPlayer.swift
@@ -78,9 +78,9 @@ public class JustAudioPlayer {
         queueManager.$shouldShuffle
     }
 
-    private let engine = AVAudioEngine()
+    private var engine: AVAudioEngine!
 
-    private lazy var mainPlayer = SAPlayer(engine: engine)
+    private var mainPlayer: SAPlayer!
 
     // MARK: - Http headers
 
@@ -107,7 +107,10 @@ public class JustAudioPlayer {
 
     // MARK: - Constructor
 
-    public init() {
+    /// pass the same engine to different instance of `JustAudioPlayer` to play more track all together and handle actions and streams of the single track
+    public init(engine: AVAudioEngine = AVAudioEngine()) {
+        self.engine = engine
+        mainPlayer = SAPlayer(engine: engine)
         subscribeToAllSubscriptions()
     }
 


### PR DESCRIPTION
It is now possible to instantiate more than one instance of `JustAudioPlayer` with the same engine to handle more than one `AudioSource`, play/pause, streams, etc. are closely linked to the single audio source